### PR TITLE
Fix windows path resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "meteor-toolbox",
     "displayName": "Meteor Toolbox",
     "description": "Easily set up your Meteor environment (intelisense, run options and many other things).",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "private": "true",
     "publisher": "meteor-toolbox",
     "license": "MIT",

--- a/src/base-configs.js
+++ b/src/base-configs.js
@@ -7,15 +7,13 @@ const addDebugAndRunOptions = async () => {
     const filesResults = await workspace.findFiles(".vscode/launch.json");
     const fileUri = filesResults[0];
 
+    const baseConfig = BASE_LAUNCH_CONFIG.baseConfig();
     if (!fileUri) {
-        return createFileFromScratch(
-            BASE_LAUNCH_CONFIG(),
-            ".vscode/launch.json"
-        );
+        return createFileFromScratch(baseConfig, BASE_LAUNCH_CONFIG.uri);
     }
 
     return appendToExistingFile(
-        { configurations: BASE_LAUNCH_CONFIG().configurations },
+        { configurations: baseConfig.configurations },
         fileUri,
         (target, source) => {
             return uniqBy([...source, ...target], ({ name }) => name);

--- a/src/constants.js
+++ b/src/constants.js
@@ -21,50 +21,58 @@ const JSCONFIG = {
     },
 };
 
-const BASE_LAUNCH_CONFIG = () => {
-    const portToUse = workspace
-        .getConfiguration()
-        .get("conf.settingsEditor.meteorToolbox.port");
-
-    const additionalArgs =
-        workspace
+const BASE_LAUNCH_CONFIG = {
+    uri: ".vscode/launch.json",
+    baseConfig: () => {
+        const portToUse = workspace
             .getConfiguration()
-            .get("conf.settingsEditor.meteorToolbox.additionalArgs")
-            ?.split(" ") || [];
+            .get("conf.settingsEditor.meteorToolbox.port");
 
-    return {
-        version: "0.2.0",
-        configurations: [
-            {
-                type: "node",
-                request: "launch",
-                name: "Meteor: Run",
-                runtimeExecutable: "meteor",
-                outputCapture: "std",
-                noDebug: "true",
-                runtimeArgs: ["run", "--port", portToUse, ...additionalArgs],
-            },
-            {
-                type: "node",
-                request: "launch",
-                name: "Meteor: Debug",
-                runtimeExecutable: "meteor",
-                runtimeArgs: [
-                    "run",
-                    "--port",
-                    portToUse,
-                    ...additionalArgs,
-                    "--inspect-brk",
-                ],
-                outputCapture: "std",
-                serverReadyAction: {
-                    pattern: "App running at: http://localhost:([0-9]+)/",
-                    uriFormat: "http://localhost:%s",
-                    action: "debugWithChrome",
+        const additionalArgs =
+            workspace
+                .getConfiguration()
+                .get("conf.settingsEditor.meteorToolbox.additionalArgs")
+                ?.split(" ") || [];
+
+        return {
+            version: "0.2.0",
+            configurations: [
+                {
+                    type: "node",
+                    request: "launch",
+                    name: "Meteor: Run",
+                    runtimeExecutable: "meteor",
+                    outputCapture: "std",
+                    noDebug: "true",
+                    runtimeArgs: [
+                        "run",
+                        "--port",
+                        portToUse,
+                        ...additionalArgs,
+                    ],
                 },
-            },
-        ],
-    };
+                {
+                    type: "node",
+                    request: "launch",
+                    name: "Meteor: Debug",
+                    runtimeExecutable: "meteor",
+                    runtimeArgs: [
+                        "run",
+                        "--port",
+                        portToUse,
+                        ...additionalArgs,
+                        "--inspect-brk",
+                    ],
+                    outputCapture: "std",
+                    serverReadyAction: {
+                        pattern: "App running at: http://localhost:([0-9]+)/",
+                        uriFormat: "http://localhost:%s",
+                        action: "debugWithChrome",
+                    },
+                },
+            ],
+        };
+    },
 };
 
 module.exports = {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,7 +6,7 @@ const merge = require("deepmerge");
 const path = require("path");
 
 const writeToFile = async (data, targetUri) => {
-    const path = targetUri.path;
+    const path = targetUri.fsPath;
     try {
         await workspace.fs.writeFile(targetUri, data);
         console.log(`Successfully wrote to file ${path}!`);
@@ -17,19 +17,20 @@ const writeToFile = async (data, targetUri) => {
 
 const createFileFromScratch = async (data, targetPath) => {
     console.log(`${targetPath} does not exists, creating one...`);
-    const resolvedPath = path.resolve(
-        workspace.workspaceFolders[0].uri.path,
+
+    const resolvedUri = Uri.joinPath(
+        workspace.workspaceFolders[0].uri,
         targetPath
     );
 
     const baseConfigAsString = JSON.stringify(data, null, 2);
     const encodedBaseConfig = new TextEncoder().encode(baseConfigAsString);
 
-    return writeToFile(encodedBaseConfig, Uri.file(resolvedPath));
+    return writeToFile(encodedBaseConfig, resolvedUri);
 };
 
 const appendToExistingFile = async (dataObject, targetUri, arrayMergeMode) => {
-    console.log(`${targetUri.path} exists, appending needed info.`);
+    console.log(`${targetUri.fsPath} exists, appending needed info.`);
 
     const existingFileContent = await workspace.fs.readFile(targetUri);
     const existingDecodedConfig = json5.parse(
@@ -42,7 +43,7 @@ const appendToExistingFile = async (dataObject, targetUri, arrayMergeMode) => {
 
     if (isEqual(existingDecodedConfig, newConfig)) {
         console.log(
-            `Generated configs are equal to existing ones for file: ${targetUri.path}. No work to do.`
+            `Generated configs are equal to existing ones for file: ${targetUri.fsPath}. No work to do.`
         );
         return;
     }

--- a/src/packages-config.js
+++ b/src/packages-config.js
@@ -90,14 +90,9 @@ async function addImportedPackagesToJsConfig() {
         });
     });
 
-    const resolvedPath = path.resolve(
-        workspace.workspaceFolders[0].uri.path,
-        JSCONFIG.uri
-    );
-
     await appendToExistingFile(
         { compilerOptions: { paths: { ...paths } } },
-        Uri.file(resolvedPath),
+        Uri.joinPath(workspace.workspaceFolders[0].uri, JSCONFIG.uri),
         dontMerge
     );
 
@@ -175,13 +170,9 @@ async function addCustomPackageOptionsToJsConfig() {
                 return acc;
             }, {});
 
-        const resolvedPath = path.resolve(
-            workspace.workspaceFolders[0].uri.path,
-            JSCONFIG.uri
-        );
         await appendToExistingFile(
             { compilerOptions: { paths: { ...paths } } },
-            Uri.file(resolvedPath),
+            Uri.joinPath(workspace.workspaceFolders[0].uri, JSCONFIG.uri),
             dontMerge
         );
     }


### PR DESCRIPTION
`Uri.path` would leave a facing slash which then would generate a broken path when using `path.resolve`.

The fix here is to use VSCODE API to handle paths, using `Uri.joinPaths`.