### PR TITLE
[feat] - Support React and monorepos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "meteor-dev" extension will be documented in this fil
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [18/01/23]
+
+-   Run indexer on React projects.
+
 ## [07/01/23]
 
 -   Fix issue where methods declared as an object property were not being properly indexed.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Just install the extension and it will add the needed configuration for you.
 
 Note: this extensions changes the `jsconfig.json` and `.vscode/launch.json`. Remember to not include those changes to your version control system, as they are scoped to your environment.
 
-## Blaze Support
+## Meteor Language Server
 
-Meteor Toolbox is the only extension implementing a Blaze completion/definition provider. Check it in action:
+Meteor Toolbox is the only extension implementing a Meteor Language Server. It works for Blaze and React projects. Check it in action:
 
 ### Completions
 
@@ -45,6 +45,7 @@ And much more...
 ## Requirements
 
 This extension only runs inside a Meteor project.
+Monorepos are not supported yet.
 
 ## Extension Settings
 

--- a/extension.js
+++ b/extension.js
@@ -6,7 +6,6 @@ const {
 const {
     toggleAutoRunPackagesWatcher,
     clearMeteorBuildCache,
-    isUsingMeteorPackage,
     isMeteorProject,
 } = require("./src/helpers");
 const {
@@ -37,7 +36,7 @@ const disposeWatchers = () =>
  */
 async function activate(context) {
     if (!(await isMeteorProject())) {
-        console.warn(
+        console.error(
             "Not in a meteor project, not starting Meteor Toolbox extension..."
         );
         return;
@@ -127,12 +126,9 @@ async function activate(context) {
         }
     );
 
-    if (await isUsingMeteorPackage("blaze-html-templates")) {
-        console.log("Connecting to language server...");
-        context.subscriptions.push(
-            await connectToLanguageServer(context.asAbsolutePath)
-        );
-    }
+    context.subscriptions.push(
+        await connectToLanguageServer(context.asAbsolutePath)
+    );
 
     context.subscriptions.push(
         toggleAutoRunPackagesWatcherDisposable,

--- a/extension.js
+++ b/extension.js
@@ -6,7 +6,7 @@ const {
 const {
     toggleAutoRunPackagesWatcher,
     clearMeteorBuildCache,
-    isMeteorProject,
+    getMeteorProjects,
 } = require("./src/helpers");
 const {
     addImportedPackagesToJsConfig,
@@ -17,10 +17,10 @@ const {
     stopServer,
 } = require("./src/connect-to-server");
 
-const createOrUpdateJsConfigFile = () => {
-    generateBaseJsConfig();
-    addImportedPackagesToJsConfig();
-    addCustomPackageOptionsToJsConfig();
+const createOrUpdateJsConfigFile = async (workspaceUri, projectUri) => {
+    await generateBaseJsConfig(workspaceUri, projectUri);
+    await addImportedPackagesToJsConfig(workspaceUri, projectUri);
+    await addCustomPackageOptionsToJsConfig(workspaceUri);
 };
 
 let importedPackagesFileWatcher;
@@ -35,17 +35,32 @@ const disposeWatchers = () =>
  * @param {vscode.ExtensionContext} context
  */
 async function activate(context) {
-    if (!(await isMeteorProject())) {
+    const meteorProjectsByWorkspace = await getMeteorProjects();
+    if (!Object.keys(meteorProjectsByWorkspace).length) {
         console.error(
-            "Not in a meteor project, not starting Meteor Toolbox extension..."
+            "No meteor projects found, not starting Meteor Toolbox extension..."
         );
         return;
     }
 
     console.log("Starting Meteor Toolbox extension...");
 
-    addDebugAndRunOptions();
-    createOrUpdateJsConfigFile();
+    for (const workspaceKey in meteorProjectsByWorkspace) {
+        if (
+            !Object.hasOwnProperty.call(meteorProjectsByWorkspace, workspaceKey)
+        ) {
+            continue;
+        }
+
+        const workspaceUri = vscode.Uri.file(workspaceKey);
+        const meteorProjects = meteorProjectsByWorkspace[workspaceKey];
+        if (!meteorProjects.length) continue;
+
+        for (const project of meteorProjects) {
+            await addDebugAndRunOptions(workspaceUri, project);
+            await createOrUpdateJsConfigFile(workspaceUri, project);
+        }
+    }
 
     const toggleAutoRunPackagesWatcherDisposable =
         vscode.commands.registerCommand(
@@ -77,7 +92,7 @@ async function activate(context) {
                 return;
             }
 
-            createOrUpdateJsConfigFile();
+            return createOrUpdateJsConfigFile();
         }
     );
 
@@ -86,27 +101,40 @@ async function activate(context) {
     );
 
     if (autoEnabled) {
-        const currentWorkspace = vscode.workspace.workspaceFolders[0];
-        importedPackagesFileWatcher = vscode.workspace.createFileSystemWatcher(
-            new vscode.RelativePattern(
-                currentWorkspace,
-                ".meteor/{packages, versions}"
-            )
-        );
-        customPackagesFileWatcher = vscode.workspace.createFileSystemWatcher(
-            new vscode.RelativePattern(
-                currentWorkspace,
-                "packages/**/package.js"
-            )
-        );
-
-        [importedPackagesFileWatcher, customPackagesFileWatcher].forEach(
-            (watcher) => {
-                watcher.onDidChange(createOrUpdateJsConfigFile);
-                watcher.onDidCreate(createOrUpdateJsConfigFile);
-                watcher.onDidDelete(createOrUpdateJsConfigFile);
+        for (const workspaceKey in meteorProjectsByWorkspace) {
+            if (
+                !Object.hasOwnProperty.call(
+                    meteorProjectsByWorkspace,
+                    workspaceKey
+                )
+            ) {
+                return;
             }
-        );
+
+            const currentWorkspace = vscode.Uri.file(workspaceKey);
+            importedPackagesFileWatcher =
+                vscode.workspace.createFileSystemWatcher(
+                    new vscode.RelativePattern(
+                        currentWorkspace,
+                        ".meteor/{packages, versions}"
+                    )
+                );
+            customPackagesFileWatcher =
+                vscode.workspace.createFileSystemWatcher(
+                    new vscode.RelativePattern(
+                        currentWorkspace,
+                        "packages/**/package.js"
+                    )
+                );
+
+            [importedPackagesFileWatcher, customPackagesFileWatcher].forEach(
+                (watcher) => {
+                    watcher.onDidChange(createOrUpdateJsConfigFile);
+                    watcher.onDidCreate(createOrUpdateJsConfigFile);
+                    watcher.onDidDelete(createOrUpdateJsConfigFile);
+                }
+            );
+        }
     } else {
         disposeWatchers();
     }

--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
         "packages"
     ],
     "activationEvents": [
-        "workspaceContains:.meteor/release",
-        "onLanguage:spacebars",
-        "onLanguage:javascript"
+        "workspaceContains:**/.meteor/release"
     ],
     "contributes": {
         "configuration": [

--- a/server/src/definition-provider.js
+++ b/server/src/definition-provider.js
@@ -5,19 +5,22 @@ class DefinitionProvider extends ServerBase {
         super(serverInstance, documentsInstance, rootUri, indexer);
     }
 
-    onDefinitionRequest({ position, textDocument: { uri } }) {
+    async onDefinitionRequest({ position, textDocument: { uri } }) {
+        const projectUri = await this.findRootFromUri(uri);
+        if (!projectUri) return;
+
         if (this.isFileSpacebarsHTML(uri)) {
-            return this.handleFileSpacebarsHTML({ uri, position });
+            return this.handleFileSpacebarsHTML({ uri, position, projectUri });
         }
 
         if (this.isFileJS(uri)) {
-            return this.handleFileJS({ uri, position });
+            return this.handleFileJS({ uri, position, projectUri });
         }
 
         return;
     }
 
-    async handleFileJS({ uri, position }) {
+    async handleFileJS({ uri, position, projectUri }) {
         const { astWalker } = this.indexer.getFileInfo(uri);
 
         const nodeAtPosition = astWalker.getSymbolAtPosition(position);
@@ -34,7 +37,6 @@ class DefinitionProvider extends ServerBase {
             return;
         }
 
-        const projectUri = await this.findRootFromUri(uri);
         const definitionInfo =
             projectUri &&
             ((await this.indexer.methodsAndPublicationsIndexer.getLiteralInfo(
@@ -44,6 +46,7 @@ class DefinitionProvider extends ServerBase {
                 (await this.indexer.blazeIndexer.getHelperFromTemplate({
                     templateUri: this.parseUri(uri),
                     helper: nodeKey,
+                    projectUri,
                 })));
         if (!definitionInfo) {
             /**
@@ -51,7 +54,11 @@ class DefinitionProvider extends ServerBase {
              * node location. The problem is that this add unnecessary "definitions" sometimes.
              * To get around that, we check if we are searching for a template or helper.
              */
-            if (!this.indexer.blazeIndexer.htmlUsageMap[nodeAtPosition.name]) {
+            if (
+                !this.indexer.blazeIndexer.htmlUsageMap[
+                    `${projectUri.fsPath}${nodeAtPosition.name}`
+                ]
+            ) {
                 console.warn(`Didn't find definitions for ${nodeAtPosition}`);
                 return;
             }
@@ -83,7 +90,7 @@ class DefinitionProvider extends ServerBase {
         );
     }
 
-    handleFileSpacebarsHTML({ uri, position }) {
+    handleFileSpacebarsHTML({ uri, position, projectUri }) {
         const { AstWalker } = require("./ast-helpers");
         const htmlWalker = new AstWalker(
             this.getFileContent(uri),
@@ -107,6 +114,7 @@ class DefinitionProvider extends ServerBase {
                 symbol: htmlSymbol,
                 htmlWalker,
                 uri,
+                projectUri,
             });
         }
 
@@ -117,6 +125,7 @@ class DefinitionProvider extends ServerBase {
             return this.handleMustacheStatement({
                 symbol: htmlSymbol,
                 uri,
+                projectUri,
             });
         }
 
@@ -254,7 +263,7 @@ class DefinitionProvider extends ServerBase {
         );
     }
 
-    handlePartialStatement({ symbol, htmlWalker, uri }) {
+    handlePartialStatement({ symbol, htmlWalker, uri, projectUri }) {
         /**
          * Is the template defined in the same HTML file that initiated the request?
          */
@@ -269,8 +278,10 @@ class DefinitionProvider extends ServerBase {
         /**
          * OK, we need to search for the template.
          */
-        const { uri: templateUri } =
-            this.indexer.blazeIndexer.getTemplateInfo(symbol);
+        const { uri: templateUri } = this.indexer.blazeIndexer.getTemplateInfo(
+            symbol,
+            projectUri
+        );
 
         /**
          * Well, we tried but we didn't find anything useful.
@@ -357,7 +368,7 @@ class DefinitionProvider extends ServerBase {
         return visitHtmlChildren(htmlJs.children) && htmlJs;
     }
 
-    handleMustacheStatement({ symbol, uri }) {
+    handleMustacheStatement({ symbol, uri, projectUri }) {
         const wrappingTemplate = this.getWrappingTemplate({ uri, symbol });
         if (!wrappingTemplate) return;
 
@@ -371,6 +382,7 @@ class DefinitionProvider extends ServerBase {
         const helper = this.indexer.blazeIndexer.getHelperFromTemplate({
             templateName,
             helper: symbol,
+            projectUri,
         });
 
         const { start, end } = helper || {};

--- a/server/src/helpers.js
+++ b/server/src/helpers.js
@@ -78,6 +78,33 @@ class ServerBase {
             encoding: "utf-8",
         });
     }
+
+    async isUsingMeteorPackage(packageName) {
+        if (!packageName || typeof packageName !== "string") {
+            throw new Error(
+                `Expected to receive packageName string, but got: ${packageName}`
+            );
+        }
+
+        const { Utils } = require("vscode-uri");
+        const packageFilesUri = Utils.joinPath(
+            this.rootUri,
+            ".meteor",
+            "packages"
+        );
+
+        try {
+            const fileContent = await this.getFileContentPromise(
+                packageFilesUri
+            );
+
+            return !!fileContent.match(new RegExp(`^${packageName}`, "gm"))
+                ?.length;
+        } catch (e) {
+            console.error(e);
+            return false;
+        }
+    }
 }
 
 module.exports = {

--- a/server/src/indexer.js
+++ b/server/src/indexer.js
@@ -76,7 +76,7 @@ class Indexer extends ServerBase {
         });
     }
 
-    indexJsFile({ uri, astWalker, shouldIndexBlaze = true }) {
+    indexJsFile({ uri, astWalker, shouldIndexBlaze = true, projectUri }) {
         if (!astWalker || !uri) {
             throw new Error(
                 `Expected to receive uri and astWalker, but got: ${uri} and ${astWalker}`
@@ -85,11 +85,16 @@ class Indexer extends ServerBase {
 
         let previousNode;
         astWalker.walkUntil((node) => {
-            this.methodsAndPublicationsIndexer.indexDefinitions({ uri, node });
+            this.methodsAndPublicationsIndexer.indexDefinitions({
+                uri,
+                node,
+                projectUri,
+            });
             this.methodsAndPublicationsIndexer.indexUsage({
                 uri,
                 node,
                 previousNode,
+                projectUri,
             });
 
             shouldIndexBlaze && this.blazeIndexer.indexHelpers({ node, uri });
@@ -137,9 +142,14 @@ class Indexer extends ServerBase {
 
                     if (isFileHtml) {
                         shouldIndexBlaze &&
-                            this.indexHtmlFile({ uri, astWalker });
+                            this.indexHtmlFile({ uri, astWalker, projectUri });
                     } else {
-                        this.indexJsFile({ uri, astWalker, shouldIndexBlaze });
+                        this.indexJsFile({
+                            uri,
+                            astWalker,
+                            shouldIndexBlaze,
+                            projectUri,
+                        });
                     }
 
                     return {

--- a/server/src/indexer.js
+++ b/server/src/indexer.js
@@ -61,7 +61,7 @@ class Indexer extends ServerBase {
         return [...new Set(uris).values()].sort().map(this.parseUri);
     }
 
-    indexHtmlFile({ uri, astWalker }) {
+    indexHtmlFile({ uri, astWalker, projectUri }) {
         if (!astWalker || !uri) {
             throw new Error(
                 `Expected to receive uri and astWalker, but got: ${uri} and ${astWalker}`
@@ -72,6 +72,7 @@ class Indexer extends ServerBase {
             this.blazeIndexer.indexHelpersUsageAndTemplates({
                 uri,
                 node,
+                projectUri,
             });
         });
     }
@@ -97,7 +98,8 @@ class Indexer extends ServerBase {
                 projectUri,
             });
 
-            shouldIndexBlaze && this.blazeIndexer.indexHelpers({ node, uri });
+            shouldIndexBlaze &&
+                this.blazeIndexer.indexHelpers({ node, uri, projectUri });
             previousNode = node;
         });
     }

--- a/server/src/references-provider.js
+++ b/server/src/references-provider.js
@@ -5,7 +5,7 @@ class ReferencesProvider extends ServerBase {
         super(serverInstance, documentsInstance, rootUri, indexer);
     }
 
-    onReferenceRequest({ position, textDocument: { uri } }) {
+    async onReferenceRequest({ position, textDocument: { uri } }) {
         if (!this.isFileJS(uri)) {
             return;
         }
@@ -36,10 +36,15 @@ class ReferencesProvider extends ServerBase {
 
         // Find references for helpers, templateNames, and methods/publications.
         const nodeKey = nodeAtPosition.value || nodeAtPosition.name;
+        const projectUri = await this.findRootFromUri(uri);
         const usageInfoArray =
-            this.indexer.methodsAndPublicationsIndexer.getUsageInfo(nodeKey) ||
-            this.indexer.blazeIndexer.htmlUsageMap[nodeKey] ||
-            this.indexer.blazeIndexer.getTemplateInfo(nodeKey);
+            projectUri &&
+            (this.indexer.methodsAndPublicationsIndexer.getUsageInfo(
+                nodeKey,
+                projectUri
+            ) ||
+                this.indexer.blazeIndexer.htmlUsageMap[nodeKey] ||
+                this.indexer.blazeIndexer.getTemplateInfo(nodeKey));
 
         if (!Array.isArray(usageInfoArray) || !usageInfoArray.length) {
             console.warn(`No references found for ${nodeKey}`);

--- a/server/src/references-provider.js
+++ b/server/src/references-provider.js
@@ -43,8 +43,10 @@ class ReferencesProvider extends ServerBase {
                 nodeKey,
                 projectUri
             ) ||
-                this.indexer.blazeIndexer.htmlUsageMap[nodeKey] ||
-                this.indexer.blazeIndexer.getTemplateInfo(nodeKey));
+                this.indexer.blazeIndexer.htmlUsageMap[
+                    `${projectUri.fsPath}${nodeKey}`
+                ] ||
+                this.indexer.blazeIndexer.getTemplateInfo(nodeKey, projectUri));
 
         if (!Array.isArray(usageInfoArray) || !usageInfoArray.length) {
             console.warn(`No references found for ${nodeKey}`);

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -18,17 +18,14 @@ class ServerInstance {
         this.documents = new TextDocuments(TextDocument);
 
         this.connection.onInitialize(async (params) => {
-            this.rootUri =
-                params.rootUri ||
-                (params.rootPath && `file://${params.rootPath}`);
-
-            if (!this.rootUri) {
-                console.error("Not able to found rootUri");
+            this.workspaceFolders = params.workspaceFolders;
+            if (!this.workspaceFolders?.length) {
+                console.error("Not able to found workspaces folders");
                 return;
             }
 
             this.indexer = new Indexer({
-                rootUri: this.rootUri,
+                workspaceFolders: this.workspaceFolders,
                 serverInstance: this.connection,
                 documentsInstance: this.documents,
             });
@@ -39,19 +36,19 @@ class ServerInstance {
             this.definitionProvider = new DefinitionProvider(
                 this.connection,
                 this.documents,
-                this.rootUri,
+                this.workspaceFolders,
                 this.indexer
             );
             this.completionProvider = new CompletionProvider(
                 this.connection,
                 this.documents,
-                this.rootUri,
+                this.workspaceFolders,
                 this.indexer
             );
             this.referencesProvider = new ReferencesProvider(
                 this.connection,
                 this.documents,
-                this.rootUri,
+                this.workspaceFolders,
                 this.indexer
             );
 

--- a/spacebars/language-configuration.json
+++ b/spacebars/language-configuration.json
@@ -1,5 +1,4 @@
 {
-	
 	"comments": {
 		"blockComment": [ "{{!--", "--}}" ]
 	},

--- a/src/connect-to-server.js
+++ b/src/connect-to-server.js
@@ -47,6 +47,7 @@ const connectToLanguageServer = async (asAbsolutePath) => {
     await client.start();
     setupNotifications();
 
+    console.log("Connected to the server!");
     return client;
 };
 

--- a/src/connect-to-server.js
+++ b/src/connect-to-server.js
@@ -1,5 +1,7 @@
 let client;
 const connectToLanguageServer = async (asAbsolutePath) => {
+    console.log("Connecting to language server...");
+
     const {
         TransportKind,
         LanguageClient,

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,7 +23,10 @@ const JSCONFIG = {
 
 const BASE_LAUNCH_CONFIG = {
     uri: ".vscode/launch.json",
-    baseConfig: () => {
+    baseConfig: (projectUri) => {
+        const fsPath = projectUri.fsPath;
+        const projectName = fsPath.match(/[^/]*$/)[0] || "Unkwnon";
+
         const portToUse = workspace
             .getConfiguration()
             .get("conf.settingsEditor.meteorToolbox.port");
@@ -40,7 +43,7 @@ const BASE_LAUNCH_CONFIG = {
                 {
                     type: "node",
                     request: "launch",
-                    name: "Meteor: Run",
+                    name: `Meteor: Run - ${projectName}`,
                     runtimeExecutable: "meteor",
                     outputCapture: "std",
                     noDebug: "true",
@@ -50,12 +53,14 @@ const BASE_LAUNCH_CONFIG = {
                         portToUse,
                         ...additionalArgs,
                     ],
+                    cwd: fsPath,
                 },
                 {
                     type: "node",
                     request: "launch",
-                    name: "Meteor: Debug",
+                    name: `Meteor: Debug - ${projectName}`,
                     runtimeExecutable: "meteor",
+                    cwd: fsPath,
                     runtimeArgs: [
                         "run",
                         "--port",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -122,31 +122,11 @@ const isMeteorProject = async () => {
     return exists;
 };
 
-const isUsingMeteorPackage = async (pkgName) => {
-    if (!pkgName || typeof pkgName !== "string") {
-        throw new Error(`Invalid meteor package name, received: ${pkgName}`);
-    }
-
-    if (!(await isMeteorProject())) {
-        return;
-    }
-
-    const pkgFilesUri = Uri.joinPath(
-        workspace.workspaceFolders[0].uri,
-        ".meteor/packages"
-    );
-
-    const existingFileContent = await workspace.fs.readFile(pkgFilesUri);
-
-    return existingFileContent.includes(pkgName);
-};
-
 module.exports = {
     createFileFromScratch,
     appendToExistingFile,
     toggleAutoRunPackagesWatcher,
     isWindows,
     clearMeteorBuildCache,
-    isUsingMeteorPackage,
     isMeteorProject,
 };


### PR DESCRIPTION
- [x] Enable indexing for methods and publications on React projects.
- [x] Enable support for monorepos on the client-side
- [ ] Enable support for monorepos on the LS
   - [x] Adapt providers to account for workspace folders and meteor project paths
   - [ ] If no result is found when searching in the current workspace/project, fallback to check in others too. Only return nothing if nothing is found.