### PR TITLE
Omit warning ts(2686) on JSX files without import React

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -8,7 +8,7 @@ const JSCONFIG = {
         compilerOptions: {
             checkJs: true,
             allowJs: true,
-            jsx: "react",
+            jsx: "react-jsx",
             baseUrl: ".",
             paths: {
                 ["/*"]: ["./*"],


### PR DESCRIPTION
Since React 17, the import statement

```
import React from "react";
```

is no longer necessary. To omit the warning *'React' refers to a UMD global, but the current file is a module* ts(2686), the compiler option for jsx must be set to *react-jsx*.

My manual changes to *jsconfig.json* are regularly overwritten by the Meteor Toolbox.

Thanks for providing the Meteor Toolbox! Looking forward to having React support soon, as PR #11 proposes.